### PR TITLE
Add favicon link

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>Blockly Educational Playground</title>
     <meta name="description" content="Learn programming with visual blocks using our interactive Blockly playground. Drag and drop blocks to create programs and see results in real-time.">
+
+    <link rel="icon" href="/favicon.ico" />
     
     <!-- Google Blockly CDN -->
     <script src="https://unpkg.com/blockly/blockly.min.js"></script>


### PR DESCRIPTION
## Summary
- ensure the page uses `client/public/favicon.ico`

## Testing
- `npm run check` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684fbd9b7a248325b315eadb081da4ac